### PR TITLE
feat: Implementar inicio de sesión con correo electrónico, closes 35

### DIFF
--- a/siras10/app/Http/Requests/Auth/LoginRequest.php
+++ b/siras10/app/Http/Requests/Auth/LoginRequest.php
@@ -26,9 +26,9 @@ class LoginRequest extends FormRequest
      */
     public function rules(): array
     {
-        // CAMBIO: Se valida 'nombreUsuario' en lugar de 'email'.
+        // CAMBIO: Se valida 'correo' en lugar de 'nombreUsuario'.
         return [
-            'nombreUsuario' => ['required', 'string'],
+            'correo' => ['required', 'string', 'email'],
             'password' => ['required', 'string'],
         ];
     }
@@ -42,13 +42,14 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        // CAMBIO: Se intenta autenticar con 'nombreUsuario' y 'password'.
-        if (! Auth::attempt(['nombreUsuario' => $this->input('nombreUsuario'), 'password' => $this->input('password')], $this->boolean('remember'))) {
+        // CAMBIO: Se intenta autenticar con 'correo' y 'password'.
+        // Laravel usará 'contrasenia' automáticamente gracias al método getAuthPassword() en tu modelo Usuario.
+        if (! Auth::attempt(['correo' => $this->input('correo'), 'password' => $this->input('password')], $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([
-                // CAMBIO: El error se asocia al campo 'nombreUsuario'.
-                'nombreUsuario' => trans('auth.failed'),
+                // CAMBIO: El error se asocia al campo 'correo'.
+                'correo' => trans('auth.failed'),
             ]);
         }
 
@@ -71,8 +72,8 @@ class LoginRequest extends FormRequest
         $seconds = RateLimiter::availableIn($this->throttleKey());
 
         throw ValidationException::withMessages([
-            // CAMBIO: El error de "demasiados intentos" se asocia a 'nombreUsuario'.
-            'nombreUsuario' => trans('auth.throttle', [
+            // CAMBIO: El error de "demasiados intentos" se asocia a 'correo'.
+            'correo' => trans('auth.throttle', [
                 'seconds' => $seconds,
                 'minutes' => ceil($seconds / 60),
             ]),
@@ -84,7 +85,7 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        // CAMBIO: La clave para limitar intentos se genera con 'nombreUsuario' en lugar de 'email'.
-        return Str::transliterate(Str::lower($this->input('nombreUsuario')).'|'.$this->ip());
+        // CAMBIO: La clave para limitar intentos se genera con 'correo'.
+        return Str::transliterate(Str::lower($this->input('correo')).'|'.$this->ip());
     }
 }

--- a/siras10/resources/views/auth/login.blade.php
+++ b/siras10/resources/views/auth/login.blade.php
@@ -1,20 +1,17 @@
 <x-guest-layout>
-    <!-- Session Status -->
     <x-auth-session-status class="mb-4" :status="session('status')" />
 
     <form method="POST" action="{{ route('login') }}">
         @csrf
 
-        <!-- Email Address -->
         <div>
-            <x-input-label for="nombreUsuario" :value="__('Nombre de Usuario')" />
-            <x-text-input id="nombreUsuario" class="block mt-1 w-full" type="text" name="nombreUsuario" :value="old('nombreUsuario')" required autofocus autocomplete="username" />
-            <x-input-error :messages="$errors->get('nombreUsuario')" class="mt-2" />
+            <x-input-label for="correo" :value="__('Correo Electrónico')" />
+            <x-text-input id="correo" class="block mt-1 w-full" type="email" name="correo" :value="old('correo')" required autofocus autocomplete="username" />
+            <x-input-error :messages="$errors->get('correo')" class="mt-2" />
         </div>
 
-        <!-- Password -->
         <div class="mt-4">
-            <x-input-label for="password" :value="__('Password')" />
+            <x-input-label for="password" :value="__('Contraseña')" />
 
             <x-text-input id="password" class="block mt-1 w-full"
                             type="password"
@@ -24,7 +21,6 @@
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
 
-        <!-- Remember Me -->
         <div class="block mt-4">
             <label for="remember_me" class="inline-flex items-center">
                 <input id="remember_me" type="checkbox" class="rounded dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-indigo-600 shadow-sm focus:ring-indigo-500 dark:focus:ring-indigo-600 dark:focus:ring-offset-gray-800" name="remember">
@@ -35,12 +31,12 @@
         <div class="flex items-center justify-end mt-4">
             @if (Route::has('password.request'))
                 <a class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800" href="{{ route('password.request') }}">
-                    {{ __('Forgot your password?') }}
+                    {{ __('¿Olvidaste tu contraseña?') }}
                 </a>
             @endif
 
             <x-primary-button class="ms-3">
-                {{ __('Log in') }}
+                {{ __('Iniciar Sesión') }}
             </x-primary-button>
         </div>
     </form>


### PR DESCRIPTION
**Objetivo:**

Actualizar el sistema de autenticación para que los usuarios inicien sesión con su **correo electrónico** en lugar del nombre de usuario, siguiendo los cambios realizados por el equipo.

**Justificación:**
Esta modificación alinea el sistema con las convenciones modernas de inicio de sesión.

**Ajustes que se hicieron:**
-  Modificación en la vista `login.blade.php` para que solicite el campo `correo` en lugar de `nombreUsuario`.
-  Actualización del archivo `LoginRequest.php` para que valide el campo `correo` y lo utilice en el intento de autenticación 'Auth::attempt()'.